### PR TITLE
リリースタグ時に semver を注入して Docker イメージを再ビルド

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,14 +92,30 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+  # リリースタグ時は VERSION (semver) を ldflags に注入して再ビルドする。
+  # --version がリリースバージョンを表示するようにするため、master ビルドの
+  # SHA イメージの再タグ付けではなくタグ時点のソースからビルドし直す (#16)。
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -109,25 +125,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Resolve SHA tag
-        id: sha
-        run: |
-          # Get the commit SHA that the tag points to
-          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "sha_short=${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          echo "sha_tag=sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          echo "Resolved SHA tag: sha-${SHA_SHORT}"
-
-      - name: Verify SHA-tagged image exists
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.sha_tag }}"
-          echo "Checking for image: ${IMAGE}"
-          if ! docker buildx imagetools inspect "${IMAGE}" > /dev/null 2>&1; then
-            echo "::error::Image ${IMAGE} not found. Build the image by merging to main first."
-            exit 1
-          fi
-          echo "Image found: ${IMAGE}"
 
       - name: Extract version from tag
         id: version
@@ -144,27 +141,26 @@ jobs:
           echo "minor=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
           echo "Parsed version: ${VERSION} (major=${MAJOR}, minor=${MAJOR}.${MINOR})"
 
-      - name: Re-tag image for release
-        run: |
-          SOURCE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.sha_tag }}"
-          TARGETS=(
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}"
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}"
-          )
+      - name: Build and push release image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
 
-          echo "Source: ${SOURCE}"
-          echo "Targets:"
-          for TARGET in "${TARGETS[@]}"; do
-            echo "  - ${TARGET}"
-          done
-
-          docker buildx imagetools create \
-            --tag "${TARGETS[0]}" \
-            --tag "${TARGETS[1]}" \
-            --tag "${TARGETS[2]}" \
-            --tag "${TARGETS[3]}" \
-            "${SOURCE}"
-
-          echo "Successfully re-tagged image for release"
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -113,8 +113,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # タグ push では test ジョブがスキップされるため、通常 CI と同じ検証を再実行する
       - name: Run tests
         run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Check generated docs are up to date
+        run: python3 .claude/skills/compare-layout/scripts/generate_docs.py --check
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -126,19 +133,39 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # プレリリース (2.1.0-rc.1 等) では latest / major / minor を更新せず、
+      # 完全一致タグのみ push する
       - name: Extract version from tag
         id: version
         run: |
           # Strip 'v' prefix if present
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Tag ${TAG} is not a semver (X.Y.Z or X.Y.Z-prerelease)"
+            exit 1
+          fi
 
-          # Parse semver components
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
           MAJOR=$(echo "${VERSION}" | cut -d. -f1)
           MINOR=$(echo "${VERSION}" | cut -d. -f2)
-          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
-          echo "minor=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<TAGS_EOF"
+            echo "${IMAGE}:${VERSION}"
+            case "${VERSION}" in
+              *-*)
+                echo "Prerelease detected: only the exact version tag is pushed" >&2
+                ;;
+              *)
+                echo "${IMAGE}:latest"
+                echo "${IMAGE}:${MAJOR}.${MINOR}"
+                echo "${IMAGE}:${MAJOR}"
+                ;;
+            esac
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
           echo "Parsed version: ${VERSION} (major=${MAJOR}, minor=${MAJOR}.${MINOR})"
 
       - name: Build and push release image
@@ -148,11 +175,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+          tags: ${{ steps.version.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -172,12 +172,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Parsed version: ${VERSION} (major=${MAJOR}, minor=${MAJOR}.${MINOR})"
 
-      # OCI ラベルは metadata-action で生成する (タグの決定は上の手書きロジック)
+      # OCI ラベルは metadata-action で生成する (タグの決定は上の手書きロジック)。
+      # type=semver で org.opencontainers.image.version を v なしの semver に揃える
+      # (既定の type=ref だと v1.2.3 になり、イメージタグ・埋め込み VERSION と不一致になる)
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and push release image
         id: build

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,7 +141,11 @@ jobs:
           # Strip 'v' prefix if present
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
-          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+          # semver.org の公式パターン (build metadata を除く。+ は Docker タグに使えないため対象外)
+          NUM='0|[1-9][0-9]*'
+          IDENT="${NUM}|[0-9]*[A-Za-z-][0-9A-Za-z-]*"
+          SEMVER="^(${NUM})\\.(${NUM})\\.(${NUM})(-(${IDENT})(\\.(${IDENT}))*)?\$"
+          if ! printf '%s' "${VERSION}" | grep -Eq "${SEMVER}"; then
             echo "::error::Tag ${TAG} is not a semver (X.Y.Z or X.Y.Z-prerelease)"
             exit 1
           fi
@@ -168,6 +172,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Parsed version: ${VERSION} (major=${MAJOR}, minor=${MAJOR}.${MINOR})"
 
+      # OCI ラベルは metadata-action で生成する (タグの決定は上の手書きロジック)
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push release image
         id: build
         uses: docker/build-push-action@v5
@@ -176,6 +187,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.version.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |


### PR DESCRIPTION
## 概要

Docker イメージの `--version` が `sha-<commit>` 表記になる問題を、**案A (タグ時再ビルド)** で解消します。

Closes #16

## 変更内容

`.github/workflows/docker-publish.yml` の release ジョブを変更:

- 変更前: master push で作った `sha-*` イメージを `latest` / semver に**再タグ付け** (ビルド時にリリースバージョンが未確定のため `--version` が `sha-*` になる)
- 変更後: タグ時点のソースを checkout し、`VERSION=<semver>` を ldflags に注入して**再ビルド & push** (`latest` / `x.y.z` / `x.y` / `x`)

付随して:
- タグ時にも `go test ./...` を実行 (再タグ付け前提で test ジョブがタグをスキップしていたため)
- 再ビルドしたイメージにも artifact attestation を生成
- 不要になった「SHA イメージの存在確認」ステップを削除

## トレードオフ (issue 記載のとおり)

「master でテストしたイメージそのもの」という同一性保証は失われますが、同一ソース・同一 Dockerfile からのビルドであり、タグ時にもテストを実行することで担保します。GitHub Releases のバイナリ (GoReleaser) と表記が揃います。

## 確認方法

次回リリースタグ push 後:
```bash
docker run --rm ghcr.io/scenario-test-framework/compare-files:latest /app/bin/compare_files --version
# => compare-files 2.x.x (sha-* ではなく semver)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwdHzbbtgkh724tqovxEZw