### PR TITLE
feat: 比較結果サマリーを表示 (Java 版 printDetails 互換)

### DIFF
--- a/cmd/compare_files/main.go
+++ b/cmd/compare_files/main.go
@@ -81,12 +81,13 @@ func run(args []string) int {
 	var processStatus status.ProcessStatus
 	if isFile(leftPath) {
 		slog.Info(msg.Get("log.input.modeFile"))
-		_, st, err := bulk.CompareFile(leftPath, rightPath, outputDirPath, cfg, layoutManager)
+		result, st, err := bulk.CompareFile(leftPath, rightPath, outputDirPath, cfg, layoutManager)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			slog.Error(msg.Get("exit.fail"))
 			return status.ExitCodeError
 		}
+		bulk.PrintFileSummary(result)
 		processStatus = st
 	} else {
 		slog.Info(msg.Get("log.input.modeDir"))
@@ -96,6 +97,7 @@ func run(args []string) int {
 			slog.Error(msg.Get("exit.fail"))
 			return status.ExitCodeError
 		}
+		counts.PrintSummary()
 		processStatus = counts.ProcessStatus()
 	}
 

--- a/cmd/compare_regex/main.go
+++ b/cmd/compare_regex/main.go
@@ -74,6 +74,7 @@ func run(args []string) int {
 		slog.Error(msg.Get("exit.fail"))
 		return status.ExitCodeError
 	}
+	counts.PrintSummary()
 	return cli.ExitCode(counts.ProcessStatus())
 }
 

--- a/internal/bulk/summary_print.go
+++ b/internal/bulk/summary_print.go
@@ -1,0 +1,42 @@
+package bulk
+
+import (
+	"log/slog"
+
+	"github.com/scenario-test-framework/compare-files/internal/filecompare"
+	"github.com/scenario-test-framework/compare-files/internal/msg"
+)
+
+// PrintFileSummary はファイル比較結果の集計を slog へ出力します。
+// Java 版 FileCompareFacadeOutput.printDetails 相当。件数は 3 桁カンマ区切り、
+// ステータス名は CompareStatus (OK/NG/Ignore/LeftOnly/RightOnly/Error) です。
+func PrintFileSummary(result *filecompare.Result) {
+	slog.Info(msg.Get("log.summary.result"))
+	slog.Info(msg.Get("log.summary.fileUnit"))
+	slog.Info(msg.Get("log.summary.subResult", string(result.Status)))
+	slog.Info(msg.Get("log.summary.rowUnit"))
+	slog.Info(msg.Get("log.summary.totalCount", FormatCount(result.RowCount)))
+	slog.Info(msg.Get("log.summary.okCount", FormatCount(result.OkRowCount)))
+	slog.Info(msg.Get("log.summary.ngCount", FormatCount(result.NgRowCount)))
+	slog.Info(msg.Get("log.summary.ignoreCount", FormatCount(result.IgnoreRowCount)))
+	slog.Info(msg.Get("log.summary.leftOnlyCount", FormatCount(result.LeftOnlyRowCount)))
+	slog.Info(msg.Get("log.summary.rightOnlyCount", FormatCount(result.RightOnlyRowCount)))
+}
+
+// PrintSummary はディレクトリ/正規表現一括比較の集計を slog へ出力します。
+// Java 版 BaseDirCompareFacadeOutput.printDetails 相当。
+func (c *Counts) PrintSummary() {
+	slog.Info(msg.Get("log.summary.processFileCount"))
+	slog.Info(msg.Get("log.summary.success", FormatCount(int64(c.SuccessCount))))
+	slog.Info(msg.Get("log.summary.failure", FormatCount(int64(c.ErrorCount))))
+	slog.Info(msg.Get("log.summary.result"))
+	slog.Info(msg.Get("log.summary.dirUnit"))
+	slog.Info(msg.Get("log.summary.subResult", string(c.Result())))
+	slog.Info(msg.Get("log.summary.fileUnit"))
+	slog.Info(msg.Get("log.summary.totalCount", FormatCount(int64(c.TotalCount))))
+	slog.Info(msg.Get("log.summary.okCount", FormatCount(int64(c.FileOkCount))))
+	slog.Info(msg.Get("log.summary.ngCount", FormatCount(int64(c.FileNgCount))))
+	slog.Info(msg.Get("log.summary.ignoreCount", FormatCount(int64(c.FileIgnoreCount))))
+	slog.Info(msg.Get("log.summary.leftOnlyCount", FormatCount(int64(c.FileLeftOnlyCount))))
+	slog.Info(msg.Get("log.summary.rightOnlyCount", FormatCount(int64(c.FileRightOnlyCount))))
+}

--- a/internal/msg/msg.go
+++ b/internal/msg/msg.go
@@ -38,6 +38,22 @@ var appMessages = map[string]string{
 	"log.text.sort":          "    ・ソート",
 	"log.text.compare":       "    ・テキスト比較",
 
+	// 比較結果サマリー (log.summary.*)。Java 版 printDetails 相当。
+	"log.summary.processFileCount": "・処理ファイル件数",
+	"log.summary.success":          "  ・成功         : {0}",
+	"log.summary.failure":          "  ・失敗         : {0}",
+	"log.summary.result":           "・比較結果",
+	"log.summary.dirUnit":          "  ・ディレクトリ単位",
+	"log.summary.fileUnit":         "  ・ファイル単位",
+	"log.summary.rowUnit":          "  ・行単位",
+	"log.summary.subResult":        "    ・比較結果   : {0}",
+	"log.summary.totalCount":       "    ・総件数     : {0}",
+	"log.summary.okCount":          "    ・OK件数     : {0}",
+	"log.summary.ngCount":          "    ・NG件数     : {0}",
+	"log.summary.ignoreCount":      "    ・除外件数   : {0}",
+	"log.summary.leftOnlyCount":    "    ・左のみ件数 : {0}",
+	"log.summary.rightOnlyCount":   "    ・右のみ件数 : {0}",
+
 	"error.arg":         "引数の指定内容に誤りがあります。",
 	"error.parse":       "{0} のパースに失敗しました。",
 	"error.validate":    "妥当性チェックエラーが発生しました。",


### PR DESCRIPTION
## 概要

Java 版が各比較の最後にログ出力していた集計サマリー (`printDetails` 相当) を Go 版でも再現します。Go 版はこれまでこの集計表示が無く、CSV サマリー (`CompareSummary.csv`) のみでした。

## 出力例

**ディレクトリ / 正規表現比較** (`BaseDirCompareFacadeOutput.printDetails` 相当)

```
・処理ファイル件数
  ・成功         : 36
  ・失敗         : 0
・比較結果
  ・ディレクトリ単位
    ・比較結果   : NG
  ・ファイル単位
    ・総件数     : 36
    ・OK件数     : 14
    ・NG件数     : 15
    ・除外件数   : 1
    ・左のみ件数 : 3
    ・右のみ件数 : 3
```

**ファイル比較** (`FileCompareFacadeOutput.printDetails` 相当)

```
・比較結果
  ・ファイル単位
    ・比較結果   : NG
  ・行単位
    ・総件数     : 11
    ・OK件数     : 4
    ...
```

## 変更点

- `internal/bulk/summary_print.go` (新規): `PrintFileSummary(*Result)` と `(*Counts).PrintSummary()` を追加。件数整形は既存の `FormatCount` (3 桁カンマ)、ステータス名は `CompareStatus` (OK/NG/Ignore/LeftOnly/RightOnly/Error) をそのまま利用。
- `internal/msg/msg.go`: `log.summary.*` メッセージを追加。既存の進捗ログ同様 `compare_files_messages.properties` で上書き可能。
- `cmd/compare_files`, `cmd/compare_regex`: 比較後にサマリーを出力するよう配線 (ファイル比較・ディレクトリ比較・正規表現比較の全モード)。

## 補足

- 出力先は既存 slog ログと統一 (`slog` デフォルトハンドラ = stderr)。Java 版は stdout でしたが、Go 版のログ書式非互換の方針に合わせています。
- golden テストは出力ファイルを比較しログはキャプチャしないため無影響。`go build` / `go vet` / `gofmt` / 全テストクリーン。サンプルデータでファイル比較・ディレクトリ比較の出力を実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
